### PR TITLE
画像やビューの調整・削除時のポップアップの実装

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -252,7 +252,31 @@ body {
   margin: 30px auto;
 }
 
-/*検索結果表示ページ*/
+/* 削除確認モーダル */
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 999;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal-content {
+  background-color: #fff;
+  margin: 300px auto;
+  padding: 20px;
+  width: 300px;
+  text-align: center;
+}
+
+.modal-buttons {
+  margin-top: 20px;
+}
+
+/* 検索結果表示ページ */
 .link-root {
   padding: 5px 0 0 40px;
 }

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -135,6 +135,12 @@ body {
 }
 
 /*部分テンプレート 一覧表示*/
+.card-img {
+  width: 100%;
+  height: 320px;
+  object-fit: cover;
+}
+
 .wine-digest {
   display: flex;
   flex-direction: column;

--- a/app/javascript/delete.js
+++ b/app/javascript/delete.js
@@ -1,0 +1,21 @@
+function confirmDelete (){
+
+  const deleteBtn = document.getElementById('delete-wine-btn');
+  if (!deleteBtn) return null;
+  const modal = document.getElementById('confirmation-modal');
+  const confirmYesBtn = document.getElementById('confirm-yes');
+  const confirmNoBtn = document.getElementById('confirm-no');
+
+  deleteBtn.addEventListener('click', function() {
+    modal.style.display = 'block';
+
+    confirmYesBtn.addEventListener('click', function() {
+      modal.style.display = 'none';
+    });
+    confirmNoBtn.addEventListener('click', function() {
+      modal.style.display = 'none';
+    });
+  });
+};
+
+window.addEventListener('DOMContentLoaded', confirmDelete);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,9 +4,10 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require("../delete")
 import "bootstrap"
 import "../stylesheets/application"
 

--- a/app/views/wines/edit.html.erb
+++ b/app/views/wines/edit.html.erb
@@ -1,5 +1,7 @@
+<%# ヘッダーを表示 %>
 <%= render "shared/header" %>
 
+<%# ワイン情報編集フォームを表示 %>
 <div class="container-fluid">
   <div class="winenote-new col-sm-10 col-lg-8">
     <h2 class="winenote-new-title">Edit your wine note</h2>

--- a/app/views/wines/new.html.erb
+++ b/app/views/wines/new.html.erb
@@ -1,5 +1,7 @@
+<%# ヘッダーを表示 %>
 <%= render "shared/header" %>
 
+<%# ワイン情報登録フォームを表示 %>
 <div class="container-fluid">
   <div class="winenote-new col-sm-10 col-lg-8">
     <h2 class="winenote-new-title">Let's make your wine note</h2>

--- a/app/views/wines/new.html.erb
+++ b/app/views/wines/new.html.erb
@@ -9,6 +9,7 @@
 
           <%= render 'shared/error_messages', model: f.object %>
           
+          <p>※がついている項目は入力必須です</p>
           <div class="input-filed-winenote row">
             <label for="wine_images" class="col-sm-2 col-form-label">ワインの写真</label>
             <div class="col-sm-5">
@@ -20,21 +21,21 @@
           </div>
 
           <div class="input-filed-winenote row">
-            <label for="wine-name" class="col-sm-2 col-form-label">ワイン名</label>
+            <label for="wine-name" class="col-sm-2 col-form-label">ワイン名 ※</label>
             <div class="col-sm-10">
               <%= f.text_field :name, class:"form-control", id:"wine-name", placeholder:"例）オーパス・ワン" %>
             </div>
           </div>
 
           <div class="input-filed-winenote row">
-            <label for="wine-type" class="col-sm-2 col-form-label">ワインの種別</label>
+            <label for="wine-type" class="col-sm-2 col-form-label">ワインの種別 ※</label>
             <div class="col-sm-5">
               <%= f.collection_select(:type_id, Type.all, :id, :name, { include_blank: "---" }, {class:"form-select", id:"wine-type" }) %>
             </div>
           </div>
 
           <div class="input-filed-winenote row">
-            <label for="wine-country" class="col-sm-2 col-form-label">産地（国）</label>
+            <label for="wine-country" class="col-sm-2 col-form-label">産地（国） ※</label>
             <div class="col-sm-5">
               <%= f.collection_select(:country_id, Country.all, :id, :name, { include_blank: "---" }, {class:"form-select", id:"wine-country" }) %>
             </div>
@@ -62,7 +63,7 @@
           </div>
 
           <div class="input-filed-winenote row">
-            <label for="wine-star" class="col-sm-2 col-form-label">評価</label>
+            <label for="wine-star" class="col-sm-2 col-form-label">評価 ※</label>
             <div class="col-sm-5">
               <%= f.collection_select(:star_id, Star.all, :id, :name, { include_blank: "---" }, {class:"form-select", id:"wine-star" }) %>
             </div>

--- a/app/views/wines/search.html.erb
+++ b/app/views/wines/search.html.erb
@@ -1,7 +1,10 @@
+<%# ヘッダーを表示 %>
 <%= render "shared/header" %>
 
+<%# 検索バーを表示 %>
 <%= render "shared/search_bar" %>
 
+<%# ワイン一覧（検索結果）を表示 %>
 <div class="wine-items container">
   <div class="wine-items-headline">
     <h3>検索結果</h3>

--- a/app/views/wines/show.html.erb
+++ b/app/views/wines/show.html.erb
@@ -4,7 +4,7 @@
   <div class="winenote-show col-sm-10">
     <div class="row">
       <div class="container-winenote-show-photos col-sm-12 col-lg-5 d-flex justify-content-evenly">
-        <div class="winenote-show-photo col-6 img-hidden">
+        <div class="winenote-show-photo col-6">
           <% if @wine.images[0].nil? %>
             <%= image_tag "no_image.png", class:"img-thumbnail", alt:"..." %>
           <% else %>

--- a/app/views/wines/show.html.erb
+++ b/app/views/wines/show.html.erb
@@ -65,10 +65,19 @@
       <%= link_to "ワインノートを編集する", edit_wine_path(@wine), class:"btn btn-outline-secondary"%>
     </div>
     <div class="d-grid col-4">
-      <%= link_to "ワインノートを削除する", wine_path(@wine), method: :delete, class:"btn btn-outline-secondary"%>
+      <button type="button" class="btn btn-outline-secondary" id="delete-wine-btn">ワインノートを削除する</button>
     </div>
   </div>
 </div>
 
-
-
+<%# 削除確認用モーダル %>
+<div id="confirmation-modal" class="modal">
+  <div class="modal-content">
+    <p>ワイン情報を削除しますか？</p>
+    <p>※テイスティングシートも同時に削除されます</p>
+    <div class="modal-buttons">
+      <%= link_to 'はい', wine_path(@wine), method: :delete, class:"btn btn-outline-secondary col-sm-6 col-md-2", id: "confirm-yes" %>
+      <button type="button" class="btn btn-outline-secondary col-sm-6 col-md-2" id="confirm-no">いいえ</button>
+    </div>
+  </div>
+</div>

--- a/app/views/wines/show.html.erb
+++ b/app/views/wines/show.html.erb
@@ -1,8 +1,11 @@
+<%# ヘッダーを表示 %>
 <%= render "shared/header" %>
 
+<%# ワイン情報詳細を表示 %>
 <div class="container">
   <div class="winenote-show col-sm-10">
     <div class="row">
+    
       <div class="container-winenote-show-photos col-sm-12 col-lg-5 d-flex justify-content-evenly">
         <div class="winenote-show-photo col-6">
           <% if @wine.images[0].nil? %>
@@ -50,10 +53,12 @@
           </div>
         </div>
       </div>
+
     </div>
   </div>
 </div>
 
+<%# 編集・削除ボタンを表示 %>
 <div class="container">
   <div class="winenote-edit col-sm-10 d-flex justify-content-evenly">
     <div class="d-grid col-4">
@@ -64,3 +69,6 @@
     </div>
   </div>
 </div>
+
+
+

--- a/app/views/wines/user_wines.erb
+++ b/app/views/wines/user_wines.erb
@@ -11,20 +11,6 @@
       <%= render partial: "shared/index", locals: { wine: wine } %>
     <% end %>
   </div>
-
-  
-<%# 最後に消す %>
-  <div class="col-sm-4 col-lg-2 mb-5">
-    <div class="card bg-light text-white">
-      <%= image_tag "wine_sample.jpg", class:"card-img", alt:"..." %>
-      <div class="wine-digest card-img-overlay">
-        <h5 class="card-title">見本のカード</h5>
-        <p class="wine-star-mihon card-text">★★★★★</p>
-        <p class="card-text">2023-06-22</p>
-      </div>
-    </div>
-  </div>
-<%# 最後に消す %>
 </div>
 
 <%= link_to(new_wine_path, class: 'wine-new-btn') do %>

--- a/app/views/wines/user_wines.erb
+++ b/app/views/wines/user_wines.erb
@@ -1,7 +1,10 @@
+<%# ヘッダーを表示 %>
 <%= render "shared/header" %>
 
+<%# 検索バーを表示 %>
 <%= render "shared/search_bar" %>
 
+<%# ワイン一覧を表示 %>
 <div class="wine-items container">
   <div class="wine-items-headline">
     <h3><%= current_user.nickname %> さんのワインノート</h3>
@@ -13,6 +16,7 @@
   </div>
 </div>
 
+<%# ワイン情報登録へのリンク %>
 <%= link_to(new_wine_path, class: 'wine-new-btn') do %>
   <span class='wine-new-btn-text'>ワインを登録</span>
   <%= image_tag 'icon_glass.png' , size: '185x50' ,class: "wine-new-btn-icon" %>


### PR DESCRIPTION
# What
・ワイン一覧の表示画像サイズが同じになるよう調整
・ビューを微調整（入力必須項目の明示、コメントの追加）
・削除時の確認用ポップアップの実装

# Why
・画像サイズによる縦幅の違いを訂正し一覧ぺージに統一感を出し、見やすくするため。
・コードの可読性をあげるため。
・削除時に意思の確認ができるようにするため